### PR TITLE
Expose main site moderator IDs

### DIFF
--- a/src/Endpoint.php
+++ b/src/Endpoint.php
@@ -40,4 +40,5 @@ abstract class Endpoint
     // main site info
     const MAINSITE_URLS_START          = 500;
     const MAINSITE_USER                = 501;
+    const MAINSITE_MODERATOR_LIST      = 502;
 }

--- a/src/EndpointURLResolver.php
+++ b/src/EndpointURLResolver.php
@@ -37,6 +37,7 @@ class EndpointURLResolver
         Endpoint::CHAT_USER_INFO_EXTRA         => 'https://%1$s/users/thumbs/%3$d?showUsage=false',
 
         Endpoint::MAINSITE_USER                => '%1$s/users/%2$d?tab=profile',
+        Endpoint::MAINSITE_MODERATOR_LIST      => '%1$s/users?tab=moderators',
     ];
 
     private $connectedRooms;

--- a/src/Room/AclDataAccessor.php
+++ b/src/Room/AclDataAccessor.php
@@ -20,6 +20,12 @@ interface AclDataAccessor
 
     /**
      * @param Room $room
+     * @return Promise<string[]>
+     */
+    function getMainSiteModerators(Room $room): Promise;
+
+    /**
+     * @param Room $room
      * @param int $userId
      * @return Promise<bool>
      */

--- a/src/Room/ChatRoomAclDataAccessor.php
+++ b/src/Room/ChatRoomAclDataAccessor.php
@@ -5,13 +5,12 @@ namespace Room11\StackChat\Room;
 use Amp\Artax\HttpClient;
 use Amp\Artax\Response as HttpResponse;
 use Amp\Promise;
-use function Amp\resolve;
-use function Room11\DOMUtils\domdocument_load_html;
 use Room11\DOMUtils\ElementNotFoundException;
-use function Room11\DOMUtils\xpath_get_elements;
 use Room11\StackChat\Auth\ActiveSessionTracker;
 use Room11\StackChat\Endpoint;
 use Room11\StackChat\EndpointURLResolver;
+use function Room11\DOMUtils\domdocument_load_html;
+use function Room11\DOMUtils\xpath_get_elements;
 
 class ChatRoomAclDataAccessor implements AclDataAccessor
 {
@@ -62,7 +61,7 @@ class ChatRoomAclDataAccessor implements AclDataAccessor
     {
         $url = $this->urlResolver->getEndpointURL($room, Endpoint::CHATROOM_INFO_ACCESS);
 
-        return resolve(function() use($url) {
+        return \Amp\resolve(function() use($url) {
             /** @var HttpResponse $response */
             $response = yield $this->httpClient->request($url);
             $doc = domdocument_load_html($response->getBody());
@@ -83,7 +82,7 @@ class ChatRoomAclDataAccessor implements AclDataAccessor
         $url = $this->urlResolver->getEndpointURL($room, Endpoint::MAINSITE_MODERATOR_LIST);
 
         $promise = $this->httpClient->request($url);
-        return resolve(function() use ($promise) {
+        return \Amp\resolve(function() use ($promise) {
             /** @var HttpResponse $response */
             $response = yield $promise;
 

--- a/src/Room/ChatRoomAclDataAccessor.php
+++ b/src/Room/ChatRoomAclDataAccessor.php
@@ -74,13 +74,11 @@ class ChatRoomAclDataAccessor implements AclDataAccessor
                 $result[$accessType] = $sectionEl !== null ? $this->parseRoomAccessSection($sectionEl) : [];
             }
 
-            $result[UserAccessType::SITE_MODERATOR] = yield $this->getMainSiteModerators($room);
-
             return $result;
         });
     }
 
-    private function getMainSiteModerators(Room $room): Promise
+    public function getMainSiteModerators(Room $room): Promise
     {
         $url = $this->urlResolver->getEndpointURL($room, Endpoint::MAINSITE_MODERATOR_LIST);
 

--- a/src/Room/ChatRoomAclDataAccessor.php
+++ b/src/Room/ChatRoomAclDataAccessor.php
@@ -62,7 +62,7 @@ class ChatRoomAclDataAccessor implements AclDataAccessor
     {
         $url = $this->urlResolver->getEndpointURL($room, Endpoint::CHATROOM_INFO_ACCESS);
 
-        return resolve(function() use($url, $room) {
+        return resolve(function() use($url) {
             /** @var HttpResponse $response */
             $response = yield $this->httpClient->request($url);
             $doc = domdocument_load_html($response->getBody());

--- a/src/Room/UserAccessType.php
+++ b/src/Room/UserAccessType.php
@@ -7,4 +7,5 @@ class UserAccessType
     const READ_ONLY = 'read-only';
     const READ_WRITE = 'read-write';
     const OWNER = 'owner';
+    const SITE_MODERATOR = 'site-moderator';
 }


### PR DESCRIPTION
Prerequisite for https://github.com/Room-11/Jeeves/issues/217 - exposes site moderator usernames + IDs ~~when calling `getRoomAccess($room)` in `AclDataAccessor`.~~

~~I wasn't sure on the place for the code, and I know the two requests could be done in parallel.~~

Feedback appreciated!